### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/shylockhuang/c16307d1-daf8-4035-8f9b-2fb7facad3c1/951c0262-e77d-4405-8793-4bcd16409d03/_apis/work/boardbadge/f43c2c6c-e621-479c-a8a4-911275726352)](https://dev.azure.com/shylockhuang/c16307d1-daf8-4035-8f9b-2fb7facad3c1/_boards/board/t/951c0262-e77d-4405-8793-4bcd16409d03/Microsoft.RequirementCategory)
 # ccc
 The framework for c language development.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/shylockhuang/c16307d1-daf8-4035-8f9b-2fb7facad3c1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.